### PR TITLE
the universal handler is not correct(i.e. doesn't work)

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,5 +1,10 @@
-import { RequestHandler } from 'express';
+import { RequestHandler } from "express";
 
+/**
+ * Merges multiple middleware to one, such that requests are
+ * passed from left to right
+ * @param middleware list of middleware to merge
+ */
 export function compose(...middleware: RequestHandler[]) {
   return middleware.reduce((a, b) => (req, res, next) =>
     a(req, res, err => {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2,14 +2,14 @@ import {
   DuplicateModelError,
   ModelNotFoundError,
   Query
-} from '@random-guys/bucket';
-import Logger from 'bunyan';
-import { Request, Response } from 'express';
-import HttpStatus from 'http-status-codes';
-import { injectable, unmanaged } from 'inversify';
-import pick from 'lodash/pick';
-import { ConstraintDataError } from './errors';
-import { IrisAPIError, IrisServerError } from '@random-guys/iris';
+} from "@random-guys/bucket";
+import Logger from "bunyan";
+import { Request, Response } from "express";
+import HttpStatus from "http-status-codes";
+import { injectable, unmanaged } from "inversify";
+import pick from "lodash/pick";
+import { ConstraintDataError } from "./errors";
+import { IrisAPIError, IrisServerError } from "@random-guys/iris";
 
 @injectable()
 export class Controller<T> {
@@ -84,7 +84,7 @@ export class Controller<T> {
     }
 
     if (err instanceof IrisServerError) {
-      err.message = 'We are having internal issues. Please bear with us';
+      err.message = "We are having internal issues. Please bear with us";
     }
 
     res.jSend.error(data, err.message, this.getHTTPErrorCode(err));
@@ -96,11 +96,11 @@ export class Controller<T> {
    * @param query Express Query object
    */
   getPaginationOptions(query: any): PaginationOptions {
-    return pick(query, ['page', 'per_page', 'projections', 'sort']);
+    return pick(query, ["page", "per_page", "projections", "sort"]);
   }
 }
 
 export type PaginationOptions = Pick<
   Query,
-  Exclude<keyof Query, 'conditions' | 'archived'>
+  Exclude<keyof Query, "conditions" | "archived">
 >;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -16,43 +16,6 @@ export class Controller<T> {
   constructor(@unmanaged() private logger: Logger) {}
 
   /**
-   * Determines the HTTP status code of an error
-   * @param err Error object
-   */
-  getHTTPErrorCode(err: any) {
-    // check if error code exists and is a valid HTTP code.
-    if (err.code >= 100 && err.code < 600) return err.code;
-
-    // integration with bucket
-    if (err instanceof ModelNotFoundError) return HttpStatus.NOT_FOUND;
-    if (err instanceof DuplicateModelError) return HttpStatus.CONFLICT;
-
-    // integration with iris
-    if (err instanceof IrisAPIError) return err.data.code;
-    if (err instanceof IrisServerError)
-      return /timeout/.test(err.message)
-        ? HttpStatus.GATEWAY_TIMEOUT
-        : HttpStatus.BAD_GATEWAY;
-
-    return HttpStatus.INTERNAL_SERVER_ERROR;
-  }
-
-  /**
-   * Safely run the handler converting any error to a JSEND error and
-   * any ensuring a Controller response T is returned.
-   * @param req request object from express
-   * @param res response object from express
-   * @param handler function that returnes a response T
-   */
-  async safely(req: Request, res: Response, handler: () => Promise<T>) {
-    try {
-      this.handleSuccess(req, res, await handler());
-    } catch (err) {
-      this.handleError(req, res, err);
-    }
-  }
-
-  /**
    * Handles operation success and sends a HTTP response
    * @param req Express request
    * @param res Express response
@@ -61,34 +24,6 @@ export class Controller<T> {
   handleSuccess(req: Request, res: Response, data: T) {
     res.jSend.success(data);
     this.logger.info({ req, res });
-  }
-
-  /**
-   * Handles operation error and sends a HTTP response
-   * @param req Express request
-   * @param res Express response
-   * @param error Error object
-   */
-  handleError(req: Request, res: Response, err: Error, data?: any) {
-    // useful when we have call an asynchrous function that might throw
-    // after we've sent a response to client
-    if (res.headersSent) return this.logger.error(err);
-
-    if (err instanceof ConstraintDataError) {
-      data = err.data;
-    }
-
-    if (err instanceof IrisAPIError) {
-      data = err.data.data;
-      err.message = err.data.message;
-    }
-
-    if (err instanceof IrisServerError) {
-      err.message = "We are having internal issues. Please bear with us";
-    }
-
-    res.jSend.error(data, err.message, this.getHTTPErrorCode(err));
-    this.logger.error({ err, res, req });
   }
 
   /**

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,8 +1,8 @@
-import joi, { ObjectSchema, SchemaMap, ValidationError } from '@hapi/joi';
-import { MongoConfig } from '@random-guys/bucket';
-import dotenv from 'dotenv';
-import mapKeys from 'lodash/mapKeys';
-import { parseError } from './validate';
+import joi, { ObjectSchema, SchemaMap, ValidationError } from "@hapi/joi";
+import { MongoConfig } from "@random-guys/bucket";
+import dotenv from "dotenv";
+import mapKeys from "lodash/mapKeys";
+import { parseError } from "./validate";
 
 export class IncompleteEnvError extends Error {
   constructor(error: ValidationError) {
@@ -57,14 +57,14 @@ function validateConfig<T extends AppConfig>(
  * Basic configuration used by all services
  */
 const basicSiberConfig = {
-  api_version: joi.string().default('/api/v1'),
+  api_version: joi.string().default("/api/v1"),
   auth_scheme: joi.string().required(),
   node_env: joi
     .string()
-    .valid('dev', 'test', 'production', 'staging')
-    .default('dev'),
-  is_production: joi.when('node_env', {
-    is: joi.valid('dev', 'test'),
+    .valid("dev", "test", "production", "staging")
+    .default("dev"),
+  is_production: joi.when("node_env", {
+    is: joi.valid("dev", "test"),
     then: joi.boolean().default(false),
     otherwise: joi.boolean().default(true)
   }),
@@ -89,8 +89,8 @@ export function siberConfig(schema: SchemaMap) {
  * Creates a field that becomes required when `NODE_ENV != dev`.
  */
 export function optionalForDev() {
-  return joi.when('node_env', {
-    is: joi.valid('production', 'staging'),
+  return joi.when("node_env", {
+    is: joi.valid("production", "staging"),
     then: joi.string().required(),
     otherwise: joi.string()
   });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -69,6 +69,11 @@ export class ConstraintDataError extends ControllerError {
   }
 }
 
+/**
+ * Get the HTTP code for an error that has a prop `code`,or is a `bucket`error, or
+ * a `iris` error. Returns `500` otherwise
+ * @param err error to parse
+ */
 export function getHTTPErrorCode(err: any) {
   // check if error code exists and is a valid HTTP code.
   if (err.code >= 100 && err.code < 600) return err.code;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -96,15 +96,10 @@ export const universalErrorHandler = (
   return async (req: Request, res: Response, next: NextFunction) => {
     if (res.headersSent) return next(err);
 
-    let data: any;
     const code = getHTTPErrorCode(err);
 
-    if (err instanceof ConstraintDataError) {
-      data = err.data;
-    }
-
     if (err instanceof IrisAPIError) {
-      data = err.data.data;
+      err.data = err.data.data;
       err.message = err.data.message;
     }
 
@@ -113,7 +108,7 @@ export const universalErrorHandler = (
       err.message = "We are having internal issues. Please bear with us";
     }
 
-    res.jSend.error(data, err.message, code);
+    res.jSend.error(err.data, err.message, code);
     logger.error({ err, res, req });
   };
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,15 +4,7 @@ import Logger from "bunyan";
 import { NextFunction, Request, RequestHandler, Response } from "express";
 import HttpStatus from "http-status-codes";
 
-export interface HttpError {
-  readonly code: number;
-}
-
-export interface HttpDataError extends HttpError {
-  readonly data: any;
-}
-
-export class ControllerError extends Error implements HttpError {
+export class ControllerError extends Error {
   code: number;
   constructor(message: string) {
     super(message);
@@ -20,7 +12,6 @@ export class ControllerError extends Error implements HttpError {
 }
 
 export class ServerError extends ControllerError {
-  code: number;
   constructor(message: string) {
     super(message);
     this.code = HttpStatus.INTERNAL_SERVER_ERROR;
@@ -69,9 +60,8 @@ export class ConstraintError extends ControllerError {
   }
 }
 
-export class ConstraintDataError extends ControllerError
-  implements HttpDataError {
-  data: any;
+export class ConstraintDataError extends ControllerError {
+  readonly data: any;
   code = HttpStatus.UNPROCESSABLE_ENTITY;
   constructor(message: string, data: any) {
     super(message);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -30,7 +30,7 @@ export class ServerError extends ControllerError {
 export class ActionNotAllowedError extends ControllerError {
   constructor(message: string) {
     super(message);
-    this.code = HttpStatus.BAD_REQUEST;
+    this.code = HttpStatus.FORBIDDEN;
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -109,6 +109,7 @@ export const universalErrorHandler = (
     }
 
     if (err instanceof IrisServerError || code === 500) {
+      err.original_message = err.message;
       err.message = "We are having internal issues. Please bear with us";
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -87,13 +87,6 @@ export function getHTTPErrorCode(err: any) {
   return HttpStatus.INTERNAL_SERVER_ERROR;
 }
 
-// function customError(err: any) {
-//   if (err instanceof Number) {
-//     return 568
-//   }
-//   return getHTTPErrorCode(err);
-// }
-
 export const universalErrorHandler = (
   err: any,
   logger: Logger
@@ -104,6 +97,8 @@ export const universalErrorHandler = (
     if (res.headersSent) return next(err);
 
     let data: any;
+    const code = getHTTPErrorCode(err);
+
     if (err instanceof ConstraintDataError) {
       data = err.data;
     }
@@ -113,11 +108,11 @@ export const universalErrorHandler = (
       err.message = err.data.message;
     }
 
-    if (err instanceof IrisServerError) {
+    if (err instanceof IrisServerError || code === 500) {
       err.message = "We are having internal issues. Please bear with us";
     }
 
-    res.jSend.error(data, err.message, this.getHTTPErrorCode(err));
+    res.jSend.error(data, err.message, code);
     logger.error({ err, res, req });
   };
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,7 @@
 import { DuplicateModelError, ModelNotFoundError } from "@random-guys/bucket";
 import { IrisAPIError, IrisServerError } from "@random-guys/iris";
 import Logger from "bunyan";
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { ErrorRequestHandler, NextFunction, Request, Response } from "express";
 import HttpStatus from "http-status-codes";
 
 export class ControllerError extends Error {
@@ -87,13 +87,17 @@ export function getHTTPErrorCode(err: any) {
   return HttpStatus.INTERNAL_SERVER_ERROR;
 }
 
-export const universalErrorHandler = (
-  err: any,
-  logger: Logger
-): RequestHandler => {
+/**
+ * A error general handler that handles:
+ * - any `ControllerError`
+ * - `bucket` errors
+ * - `iris` errors
+ * @param logger Logger to log errors and their corresponding request/response pair
+ */
+export const universalErrorHandler = (logger: Logger): ErrorRequestHandler => {
   // useful when we have call an asynchrous function that might throw
   // after we've sent a response to client
-  return async (req: Request, res: Response, next: NextFunction) => {
+  return async (err: any, req: Request, res: Response, next: NextFunction) => {
     if (res.headersSent) return next(err);
 
     const code = getHTTPErrorCode(err);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import HttpStatus from 'http-status-codes';
+import HttpStatus from "http-status-codes";
 
 export interface HttpError {
   readonly code: number;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -18,7 +18,7 @@ export class ServerError extends ControllerError {
   }
 }
 
-export class ActionNotAllowedError extends ControllerError {
+export class ForbiddenError extends ControllerError {
   constructor(message: string) {
     super(message);
     this.code = HttpStatus.FORBIDDEN;
@@ -39,7 +39,7 @@ export class BadGatewayError extends ControllerError {
   }
 }
 
-export class UnavailableGatewayError extends ControllerError {
+export class GatewayTImeoutError extends ControllerError {
   constructor(message: string) {
     super(message);
     this.code = HttpStatus.GATEWAY_TIMEOUT;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -34,6 +34,13 @@ export class ActionNotAllowedError extends ControllerError {
   }
 }
 
+export class BadRequestError extends ControllerError {
+  constructor(message: string) {
+    super(message);
+    this.code = HttpStatus.BAD_REQUEST;
+  }
+}
+
 export class BadGatewayError extends ControllerError {
   constructor(message: string) {
     super(message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
-import { JSendContract } from './jsend';
+import { JSendContract } from "./jsend";
 
-export * from './compose';
-export * from './controller';
-export * from './env';
-export * from './errors';
-export * from './jsend';
-export * from './logging';
-export * from './middleware';
-export * from './validate';
+export * from "./compose";
+export * from "./controller";
+export * from "./env";
+export * from "./errors";
+export * from "./jsend";
+export * from "./logging";
+export * from "./middleware";
+export * from "./validate";
 
 declare global {
   namespace Express {

--- a/src/jsend.ts
+++ b/src/jsend.ts
@@ -1,5 +1,5 @@
-import { RequestHandler, Response } from 'express';
-import HttpStatus from 'http-status-codes';
+import { RequestHandler, Response } from "express";
+import HttpStatus from "http-status-codes";
 
 export const refreshJSend: RequestHandler = (_req, res, next) => {
   res.jSend = new JSend(res);
@@ -16,19 +16,19 @@ export class JSend implements JSendContract {
   constructor(private readonly res: Response) {}
 
   success(data: any) {
-    this.res.json({ status: 'success', data });
+    this.res.json({ status: "success", data });
   }
 
   fail(data: any) {
     this.res
       .status(HttpStatus.EXPECTATION_FAILED)
-      .json({ status: 'fail', data });
+      .json({ status: "fail", data });
   }
 
   error(data: any, message: string, code?: number) {
     const httpCode = code || HttpStatus.INTERNAL_SERVER_ERROR;
     this.res.status(httpCode).json({
-      status: 'error',
+      status: "error",
       data,
       message,
       code: httpCode

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -53,7 +53,7 @@ export const resSerializer = (res: Response) => {
  * Extends the standard bunyan error serializer and allows custom fields to be added to the error log
  */
 export const errSerializer = (err: any) => {
-  const { url, data, req, response, config } = err;
+  const { url, data, req, response, config, original_message } = err;
   const bunyanSanitizedError = Logger.stdSerializers.err(err);
   return {
     ...bunyanSanitizedError,
@@ -61,6 +61,7 @@ export const errSerializer = (err: any) => {
     data,
     req,
     config,
+    original_message,
     ...(response &&
       typeof response === "object" && {
         response: {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,6 +1,6 @@
-import Logger from 'bunyan';
-import { NextFunction, Request, Response } from 'express';
-import uuid from 'uuid/v4';
+import Logger from "bunyan";
+import { NextFunction, Request, Response } from "express";
+import uuid from "uuid/v4";
 
 function removeSensitiveData(body: any, props: string[]) {
   const allKeys = Object.keys(body);
@@ -25,7 +25,7 @@ export function createRequestSerializer(...sensitiveProps: string[]) {
       method: req.method,
       url: req.url,
       headers: req.headers,
-      origin_service: req.headers['x-origin-service'],
+      origin_service: req.headers["x-origin-service"],
       remoteAddress: req.connection.remoteAddress,
       remotePort: req.connection.remotePort,
       id: req.id,
@@ -62,7 +62,7 @@ export const errSerializer = (err: any) => {
     req,
     config,
     ...(response &&
-      typeof response === 'object' && {
+      typeof response === "object" && {
         response: {
           config: response.config,
           data: response.data,
@@ -78,12 +78,12 @@ export const errSerializer = (err: any) => {
 export function requestTracker(log: Logger) {
   return (req: Request, _res: Response, next: NextFunction) => {
     // create a request ID for tracking if non exists
-    if (!req.headers['x-request-id']) {
-      req.headers['x-request-id'] = uuid();
+    if (!req.headers["x-request-id"]) {
+      req.headers["x-request-id"] = uuid();
     }
 
     // @ts-ignore because TS can be smarted...maybe
-    req.id = req.headers['x-request-id'];
+    req.id = req.headers["x-request-id"];
 
     // log requests
     log.info({ req });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,9 @@
-import Logger from 'bunyan';
-import cors, { CorsOptions } from 'cors';
-import express, { Application } from 'express';
-import responseTime from 'response-time';
-import { requestTracker } from './logging';
-import { refreshJSend } from './jsend';
+import Logger from "bunyan";
+import cors, { CorsOptions } from "cors";
+import express, { Application } from "express";
+import responseTime from "response-time";
+import { requestTracker } from "./logging";
+import { refreshJSend } from "./jsend";
 
 export interface SiberConfig {
   cors: boolean | CorsOptions;
@@ -18,7 +18,7 @@ export function build(app: Application, logger: Logger, conf: SiberConfig) {
 
   // CORS
   if (conf.cors) {
-    if (typeof conf.cors === 'boolean') {
+    if (typeof conf.cors === "boolean") {
       conf.cors = {
         origin: true,
         credentials: true
@@ -26,7 +26,7 @@ export function build(app: Application, logger: Logger, conf: SiberConfig) {
     }
 
     app.use(cors(conf.cors));
-    app.options('*', cors(conf.cors));
+    app.options("*", cors(conf.cors));
   }
 
   // logging and metrics

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,8 +1,8 @@
-import joi, { SchemaLike, ValidationError } from '@hapi/joi';
-import { NextFunction, Request, Response } from 'express';
-import HttpStatus from 'http-status-codes';
+import joi, { SchemaLike, ValidationError } from "@hapi/joi";
+import { NextFunction, Request, Response } from "express";
+import HttpStatus from "http-status-codes";
 
-export type ValidationContext = 'body' | 'query' | 'params';
+export type ValidationContext = "body" | "query" | "params";
 
 export function parseError(error: ValidationError) {
   return error.details.reduce((acc, curr) => {
@@ -27,7 +27,7 @@ function innerValidate(data: any, schema: SchemaLike) {
 
 export function validate(
   schema: SchemaLike,
-  context: ValidationContext = 'body'
+  context: ValidationContext = "body"
 ) {
   return (req: Request, res: Response, next: NextFunction) => {
     const { err, value } = innerValidate(req[context], schema);
@@ -38,7 +38,7 @@ export function validate(
     }
 
     //log error
-    const error = 'One or more validation errors occured';
+    const error = "One or more validation errors occured";
     return res.jSend.error(err, error, HttpStatus.UNPROCESSABLE_ENTITY);
   };
 }


### PR DESCRIPTION
This PR started with the modest goal of being able to trace `IrisServerError` and `Internal Server Error`. Thank God for showing me the light

**BREAKING CHANGES**
- `ActionNotAllowed` is now `ForbiddenError`
- `HttpError` and `HttpDataError` no longer exist
- There's no need to handle errors in you controller anymore, so `handleError` and `getHTTPErrorCode` no longer exist. You can still access `getHTTPErrorCode` as an ordinary function.

I ❤️ deleting code