### PR TITLE
instance setup for metrics change global settings

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -4,7 +4,7 @@ import { AppConfig } from "./env";
 
 export class SiberMetrics {
   private histogram: client.Histogram<"method" | "statusCode" | "path">;
-  private register: client.Registry;
+  readonly register: client.Registry;
 
   constructor(config: AppConfig) {
     this.register = new client.Registry();


### PR DESCRIPTION
## Problem
Creating a `SiberMetrics` instance changed the global registry settings.

## Solution
Created internal registry to isolate changes