### PR TITLE
proxyFrom only supports a single event. 

### DIFF
--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -73,7 +73,7 @@ function patch<T>(event: string, data?: T) {
  * @param emitter the event emitter to listen on
  * @param eventMap map of source events to destination events
  */
-export function proxy<T>(
+export function proxy(
   logger: Logger,
   req: Request,
   res: Response,
@@ -85,7 +85,7 @@ export function proxy<T>(
     res.write(":\n\n");
   }, 10000);
 
-  const handlerFn = (destination: string) => (e: T) => {
+  const handlerFn = (destination: string) => (e: any) => {
     res.write(patch(destination, e));
     logger.info({ req, data: e }, `Sending ${destination} event`);
   };

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -71,16 +71,14 @@ function patch<T>(event: string, data?: T) {
  * @param req express Request
  * @param res express Response
  * @param emitter the event emitter to listen on
- * @param source the event to listen to
- * @param destination the event to emit
+ * @param eventMap map of source events to destination events
  */
 export function proxy<T>(
   logger: Logger,
   req: Request,
   res: Response,
   emitter: EventEmitter,
-  source: string,
-  destination: string
+  eventMap: object
 ) {
   // keep connection alive
   const handle = setInterval(() => {
@@ -88,7 +86,7 @@ export function proxy<T>(
     logger.info({ req }, "Sent keep-alive message");
   }, 3000);
 
-  const handler = (e: T) => {
+  const handlerFn = (destination: string) => (e: T) => {
     patch(destination, e);
     logger.info({ req, data: e }, `Sending ${destination} event`);
   };
@@ -103,10 +101,14 @@ export function proxy<T>(
   logger.info({ req, res }, "Started SSE stream");
 
   res.on("close", () => {
-    emitter.removeListener(source, handler);
+    Object.keys(eventMap).forEach(event => {
+      emitter.removeListener(event, handlerFn(eventMap[event]));
+    });
     clearInterval(handle);
     logger.info({ req }, "Cleaned up SSE");
   });
 
-  emitter.on(source, handler);
+  Object.keys(eventMap).forEach(event => {
+    emitter.on(event, handlerFn(eventMap[event]));
+  });
 }

--- a/src/chunks.ts
+++ b/src/chunks.ts
@@ -83,11 +83,10 @@ export function proxy<T>(
   // keep connection alive
   const handle = setInterval(() => {
     res.write(":\n\n");
-    logger.info({ req }, "Sent keep-alive message");
-  }, 3000);
+  }, 10000);
 
   const handlerFn = (destination: string) => (e: T) => {
-    patch(destination, e);
+    res.write(patch(destination, e));
     logger.info({ req, data: e }, `Sending ${destination} event`);
   };
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -29,17 +29,15 @@ export class Controller<T> {
    * @param req express Request
    * @param res express Response
    * @param emitter the event emitter to listen on
-   * @param source source event on the `EventEmitter`
-   * @param dest destination event to use with SSE.
+   * @param eventMap map of source events to destination events
    */
-  async proxyFrom(
+  proxyFrom(
     req: Request,
     res: Response,
     emitter: EventEmitter,
-    source: string,
-    dest: string
+    eventMap: object
   ) {
-    proxy(this.logger, req, res, emitter, source, dest);
+    return proxy(this.logger, req, res, emitter, eventMap);
   }
 
   /**


### PR DESCRIPTION
## Additional Description
`proxyFrom` was meant to setup an SSE stream and proxy events from an event emitter to the client. With source and destination parameters, the events that could be proxied are limited to one. I switched to using an event map so there can be on than one event being proxied. Also used the chance to fix an existing bug in the implementation of `proxyFrom`.

**Note**: Keep-Alive messages are no longer logged